### PR TITLE
Add Deployment Mode environment variable to Netlify ENV

### DIFF
--- a/src/coa-publisher-basic/src/views/build.py
+++ b/src/coa-publisher-basic/src/views/build.py
@@ -25,8 +25,8 @@ def build():
     if CMS_MEDIA: netlify_env["CMS_MEDIA"] = CMS_MEDIA
     CMS_DOCS = data.get('CMS_DOCS')
     if CMS_DOCS: netlify_env["CMS_DOCS"] = CMS_DOCS
-    FEEDBACK_API = data.get('FEEDBACK_API')
-    if FEEDBACK_API: netlify_env["FEEDBACK_API"] = FEEDBACK_API
+    DEPLOYMENT_MODE = data.get('DEPLOYMENT_MODE')
+    if DEPLOYMENT_MODE: netlify_env["DEPLOYMENT_MODE"] = DEPLOYMENT_MODE
 
     # Create Site if it doesn't already exist
     site = get_site(site_name)

--- a/src/coa-publisher-basic/src/views/build.py
+++ b/src/coa-publisher-basic/src/views/build.py
@@ -25,6 +25,8 @@ def build():
     if CMS_MEDIA: netlify_env["CMS_MEDIA"] = CMS_MEDIA
     CMS_DOCS = data.get('CMS_DOCS')
     if CMS_DOCS: netlify_env["CMS_DOCS"] = CMS_DOCS
+    FEEDBACK_API = data.get('FEEDBACK_API')
+    if FEEDBACK_API: netlify_env["FEEDBACK_API"] = FEEDBACK_API
 
     # Create Site if it doesn't already exist
     site = get_site(site_name)

--- a/src/coa-publisher-basic/src/views/publish.py
+++ b/src/coa-publisher-basic/src/views/publish.py
@@ -20,6 +20,7 @@ def publish():
     # Handle optional Args
     CMS_MEDIA = data.get('CMS_MEDIA')
     CMS_DOCS = data.get('CMS_DOCS')
+    FEEDBACK_API = data.get('FEEDBACK_API')
 
     # Get netlify site data
     site = get_site(site_name)
@@ -33,6 +34,7 @@ def publish():
     netlify_env["CMS_API"] = CMS_API
     if CMS_MEDIA: netlify_env["CMS_MEDIA"] = CMS_MEDIA
     if CMS_DOCS: netlify_env["CMS_DOCS"] = CMS_DOCS
+    if FEEDBACK_API: netlify_env["FEEDBACK_API"] = FEEDBACK_API
     update_site(site_id, {
         "build_settings": {
             "env": netlify_env,

--- a/src/coa-publisher-basic/src/views/publish.py
+++ b/src/coa-publisher-basic/src/views/publish.py
@@ -20,7 +20,7 @@ def publish():
     # Handle optional Args
     CMS_MEDIA = data.get('CMS_MEDIA')
     CMS_DOCS = data.get('CMS_DOCS')
-    FEEDBACK_API = data.get('FEEDBACK_API')
+    DEPLOYMENT_MODE = data.get('DEPLOYMENT_MODE')
 
     # Get netlify site data
     site = get_site(site_name)
@@ -34,7 +34,7 @@ def publish():
     netlify_env["CMS_API"] = CMS_API
     if CMS_MEDIA: netlify_env["CMS_MEDIA"] = CMS_MEDIA
     if CMS_DOCS: netlify_env["CMS_DOCS"] = CMS_DOCS
-    if FEEDBACK_API: netlify_env["FEEDBACK_API"] = FEEDBACK_API
+    if DEPLOYMENT_MODE: netlify_env["DEPLOYMENT_MODE"] = DEPLOYMENT_MODE
     update_site(site_id, {
         "build_settings": {
             "env": netlify_env,


### PR DESCRIPTION
In order to keep some consistency between environment variables in netlify vs aws, this PR adds `DEPLOYMENT_MODE` to the variables sent to netlify. 

`DEPLOYMENT_MODE` is set as `LOCAL` in branchConfig in janis. 