### PR TITLE
make site name lowercase

### DIFF
--- a/src/coa-publisher-mvp/src/views/build.py
+++ b/src/coa-publisher-mvp/src/views/build.py
@@ -11,7 +11,7 @@ def build():
     data = request.get_json(force=True)
     netlify_env = {} # env vars to plug into netlify site
     # Handle janis_branch arg
-    janis_branch = data.get('janis_branch')
+    janis_branch = data.get('janis_branch').lower()
     if not janis_branch:
         return handle_missing_arg('janis_branch')
     site_name = f'janis-{janis_branch}'

--- a/src/coa-publisher-mvp/src/views/build.py
+++ b/src/coa-publisher-mvp/src/views/build.py
@@ -43,6 +43,9 @@ def build():
         if not validate_janis_branch(janis_branch):
             return handle_error(f"[{janis_branch}] is not a valid janis_branch", 400)
         site = create_site(site_name, janis_branch, netlify_env)
+        # If create_site does not successfully create a site, it returns an error message
+        if not site["id"]:
+            return handle_error(f"{site}", 404)
         site_id = site["id"]
         site_url = site["url"]
 

--- a/src/coa-publisher-mvp/src/views/publish.py
+++ b/src/coa-publisher-mvp/src/views/publish.py
@@ -9,7 +9,7 @@ from helpers.netlify import get_site, update_site, get_publish_hook, run_publish
 def publish():
     data = request.get_json(force=True)
     # Handle janis_branch arg
-    janis_branch = data.get('janis_branch')
+    janis_branch = data.get('janis_branch').lower()
     if not janis_branch:
         return handle_missing_arg('janis_branch')
     site_name = f'janis-{janis_branch}' # name of the netlify site


### PR DESCRIPTION

I discovered an edge case where if your janis branch name contained uppercase (ex:, 3291-JAWS-guide), publisher couldn't find it in the list of netlify sites because the sites were all in lowercase. But then when publisher tried to make a new site, netify errored because the name of the site was not unique. 

Now the site name is lowercased in build.py and publish.py. I also added an error message, I picked 404 (because site name not found), but let me know if you want a different response. 